### PR TITLE
Return autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ This may be useful if you want to put your project in a web-readable directory b
     # replace "include __DIR__.'/vendor/autoload.php';" with "include __DIR__.'/vendor.phar';"
     vim functions.php
 
+**Get composer's autoloader**
+
+You can also get access to the autoloader object if needed. The phar file will return the autoloader. With this functionality you can add on your own project's namespaced files into the autoloader.
+
+```php
+$autoload = require_once __DIR__ . '/vendor.phar';
+$autoload->add('MyNamespace', __DIR__ . '/src');
+```
+
 ## Copyright
 
 Copyright dxw 2015 - see [COPYING.md](COPYING.md)

--- a/bin/phar-install
+++ b/bin/phar-install
@@ -39,7 +39,7 @@ foreach (new RecursiveIteratorIterator($di) as $filename => $file) {
 
 $rand = sprintf('%x', mt_rand());
 
-$phar->setStub("<?php Phar::mapPhar('{$rand}'); include('phar://{$rand}/vendor/autoload.php'); __HALT_COMPILER();");
+$phar->setStub("<?php Phar::mapPhar('{$rand}'); return include('phar://{$rand}/vendor/autoload.php'); __HALT_COMPILER();");
 EOF
 
 mv -f $TMP_FILE $PHAR


### PR DESCRIPTION
Add a return statement to the vendor.phar stub so the autoloader object is exposed.

I have situations where I need to add another autoloader class path map to the composer autoloader.