### PR TITLE
Feature/avoid hard coding developer paths

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-versions: ['7.0.22', '7.1', '7.2', '7.3', '7.4']

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-versions: ['7.0.22', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ $autoload = require_once __DIR__ . '/vendor.phar';
 $autoload->add('MyNamespace', __DIR__ . '/src');
 ```
 
+## Deployed WordPress paths
+
+For WordPress developers, any path created by Composer for the
+autoloader is automatically re-written so that:
+
+    /path/to/wp-content/...
+
+becomes:
+
+    /var/www/html/wp-content/...
+
+The path prefix can be controlled by setting the `PHAR_INSTALL_PATH_TO_WP_CONTENT`
+environment variable.
+
+By default, Composer hard-codes absolute paths in classmaps,
+and if you run `phar-install` on a development machine then
+deploy the phar file to a live environment, you may see error
+messages that reflect the contents of the classmap, rather
+than the structure of your application.
+
+The re-write that `phar-install` performs is intended to ensure
+that classes take less time to load and that your error messages
+are consistent with the files you see on disk.
+
 ## Copyright
 
 Copyright dxw 2015 - see [COPYING.md](COPYING.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This may be useful if you want to put your project in a web-readable directory b
 
 Add the following to `composer.json`:
 
-```
+```json
   "scripts": {
     "post-update-cmd": "vendor/bin/phar-install"
   },
@@ -16,7 +16,7 @@ Add the following to `composer.json`:
 
 Add phar-install:
 
-```
+```shell
 composer require --dev dxw/phar-install
 ```
 

--- a/bin/phar-install
+++ b/bin/phar-install
@@ -6,7 +6,8 @@ set -e
 
 export TMP_DIR=/tmp/phar-install-tmp-dir
 export TMP_FILE=/tmp/phar-install-tmp.phar
-export PHAR=`pwd`/vendor.phar
+PHAR=$(pwd)/vendor.phar
+export PHAR
 # No trailing slash, it's added by sed below.
 export PHAR_INSTALL_PATH_TO_WP_CONTENT="/var/www/html"
 
@@ -54,6 +55,6 @@ $rand = sprintf('%x', mt_rand());
 $phar->setStub("<?php Phar::mapPhar('{$rand}'); return include('phar://{$rand}/vendor/autoload.php'); __HALT_COMPILER();");
 EOF
 
-mv -f $TMP_FILE $PHAR
+mv -f $TMP_FILE "$PHAR"
 
 rm -rf $TMP_DIR $TMP_FILE

--- a/bin/phar-install
+++ b/bin/phar-install
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -xe
+#!/bin/bash
+set -e
 # This is a shell script instead of a PHP script because we need to be able to set an ini option that ini_set() can't set
 
 # Temp locations
@@ -7,6 +7,16 @@ set -xe
 export TMP_DIR=/tmp/phar-install-tmp-dir
 export TMP_FILE=/tmp/phar-install-tmp.phar
 export PHAR=`pwd`/vendor.phar
+# No trailing slash, it's added by sed below.
+export PHAR_INSTALL_PATH_TO_WP_CONTENT="/var/www/html"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  # BSD sed
+  SED_INPLACE_OPT="-i '.bak'"
+else
+  # shellcheck disable=SC2034
+  SED_INPLACE_OPT="-i"
+fi
 
 # Cleanup
 
@@ -18,6 +28,15 @@ mkdir -p $TMP_DIR
 COMPOSER_VENDOR_DIR=$TMP_DIR/vendor composer install --no-dev --no-interaction
 
 cd $TMP_DIR
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  find . -type f -name "autoload*.php" -print0 | \
+  xargs -0 sed -i '' -E "s|'[^']*/wp-content/(.*)'|'${PHAR_INSTALL_PATH_TO_WP_CONTENT}/wp-content/\1'|g"
+  rm -Rf "*.bak"
+else
+  find . -type f -name 'autoload*.php' -print0 | \
+  xargs -0 sed -i -E "s|'[^']*/wp-content/(.*)'|'/var/www/html/wp-content/\1'|g"
+fi
 
 php -d phar.readonly=Off <<'EOF'
 <?php


### PR DESCRIPTION
By default, Composer creates a classmap of PHP classes to source files. Where those source files are written into the application or repository, the Composer classmap will hard code absolute paths to those files within the classmap.

In situations where a phar file is created on a development machine and then deployed to a live environment this is unhelpful because the absolute paths will not exist where the `vendor.phar` is loaded.

This commit re-writes the autoload files generated by Composer to replace the absolute paths with a common path to wp-content which is used in many hosting environments:

    /var/www/html

For users who prefer not to have this, the `PHAR_INSTALL_PATH_TO_WP_CONTENT` environment variable can be used to change the path.

See:
    https://getcomposer.org/doc/articles/autoloader-optimization.md

## Testing

It's probably easiest not to test here, but to copy the `phar-install` file into a binary that you already have in a site repo theme. Run `./vendor/bin/phar-install` with the new code and check that the site theme still loads.

You can also check for hard-coded paths in the `vendor.phar` file by running `strings vendor.phar | grep Users`.

I'm not sure whether we want to go much further with testing on Linux, but `sed` is annoyingly not very portable between GNU and BSD versions.