### PR TITLE
Fix/hard coded paths

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0.22', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This may be useful if you want to put your project in a web-readable directory b
 
 Add the following to `composer.json`:
 
-```
+```json
   "scripts": {
     "post-update-cmd": "vendor/bin/phar-install"
   },
@@ -16,7 +16,7 @@ Add the following to `composer.json`:
 
 Add phar-install:
 
-```
+```console
 composer require --dev dxw/phar-install
 ```
 

--- a/bin/phar-install
+++ b/bin/phar-install
@@ -14,10 +14,21 @@ rm -rf $TMP_DIR $TMP_FILE
 mkdir -p $TMP_DIR
 
 # Install dependencies
+#
+# Copy composer.{json,lock} into $TMP_DIR and run composer install from there
+# (rather than using COMPOSER_VENDOR_DIR to point an out-of-tree vendor dir at
+# $TMP_DIR) so that composer's generated autoload files express $baseDir as
+# dirname($vendorDir) rather than hard-coding the host's absolute project path.
+# That hard-coding would otherwise make the phar non-portable across machines.
 
-COMPOSER_VENDOR_DIR=$TMP_DIR/vendor composer install --no-dev --no-interaction
+cp composer.json $TMP_DIR/
+[ -f composer.lock ] && cp composer.lock $TMP_DIR/
 
 cd $TMP_DIR
+
+composer install --no-dev --no-interaction
+
+rm -f composer.json composer.lock
 
 php -d phar.readonly=Off <<'EOF'
 <?php

--- a/bin/phar-install
+++ b/bin/phar-install
@@ -6,7 +6,8 @@ set -xe
 
 export TMP_DIR=/tmp/phar-install-tmp-dir
 export TMP_FILE=/tmp/phar-install-tmp.phar
-export PHAR=`pwd`/vendor.phar
+PHAR=$(pwd)/vendor.phar
+export PHAR
 
 # Cleanup
 
@@ -46,6 +47,6 @@ $rand = sprintf('%x', mt_rand());
 $phar->setStub("<?php Phar::mapPhar('{$rand}'); return include('phar://{$rand}/vendor/autoload.php'); __HALT_COMPILER();");
 EOF
 
-mv -f $TMP_FILE $PHAR
+mv -f $TMP_FILE "$PHAR"
 
 rm -rf $TMP_DIR $TMP_FILE

--- a/tests/test.php
+++ b/tests/test.php
@@ -84,4 +84,19 @@ if ($paths !== EXPECTED) {
     exit(1);
 }
 
+// Portability check: composer's generated autoload files must not bake in any
+// absolute host path. If they do (e.g. `$baseDir = '/home/user/project';`),
+// the phar will autoload from non-existent paths on any other machine.
+$hostPath = getcwd();
+foreach (new \RecursiveIteratorIterator($phar) as $file) {
+    if (substr($file->getPathname(), -4) !== '.php') {
+        continue;
+    }
+    $contents = file_get_contents($file->getPathname());
+    if (strpos($contents, $hostPath) !== false) {
+        echo "TEST FAILED: host path {$hostPath} leaked into ".$file->getPathname()."\n";
+        exit(1);
+    }
+}
+
 echo "Test succeeded!\n";


### PR DESCRIPTION
Replaces #13 

By default, Composer creates a classmap of PHP classes to source files. Where those source files are written into the application or repository, the Composer classmap will hard code absolute paths to those files within the classmap.

In situations where a phar file is created on a development machine and then deployed to a live environment this is unhelpful because the absolute paths will not exist where the vendor.phar is loaded.

The cause of this behaviour is that the composer.{json,lock} files exist outside of the temporary directory used to create the Phar and the fix in this commit is just to copy them over so that $vendorDir can be used.

## Testing

Copy `bin/phar-install` into the `vendor/bin` of a site repo you have open, and run `./vendor/bin/phar-install`.

Check the Phar file for hard-coded paths:

```console
❯ strings vendor.phar | grep Users                                                                                                                                                                   
...

❯ strings vendor.phar | grep "/tmp"                                                                                                                                                                    

...
```

Run the project or run `phar-install` in a couple of themes / plugins etc. and check the site does not fail.